### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This package could be downloaded via `install_github()` function from `devtools`
 ```R
 install.packages("devtools")
 library(devtools)
-devtools::install_github("twangxxx/netZoo")
+devtools::install_github("twangxxx/netZooR")
 
 ```
 ## Data Resources


### PR DESCRIPTION
fixed naming bug in install readme: 'netZoo' > 'netZooR'