### PR TITLE
update crane fix

### DIFF
--- a/R/CRANE.R
+++ b/R/CRANE.R
@@ -110,7 +110,7 @@ alpacaCrane = function(input,alp,alpha=0.1,beta=0,iteration=30,isParallel=F){
   tstat=c()
   if (identical(names(alp[[2]]),rownames(df))){
     for (i in 1:nrow(df)){
-      if (rownames(df)[i]=="" || sd(df[i,])==0){
+      if (rownames(df)[i]=="" || sd(df[i,], rm.na=TRUE)==0){
         isSig=c(isSig,NA)
         next
       }


### PR DESCRIPTION
- Standard deviation of ALPACA scores returns NA, turns out that ALPACA returns NAN for some nodes.
- Thought this was fixed in https://github.com/netZoo/netZooR/pull/238 and subseqent https://github.com/netZoo/netZooR/pull/239 but it seems to be a different issue
- set sd computation to remove NAs