### PR TITLE
Fixed dependency on uchardet

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ biocViews:
          Transcription, 
          Microarray,   
          GraphAndNetwork
-Imports: 
+Imports:
+    RCy3, 
     viridisLite,
     STRINGdb,
     Biobase,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,6 @@ biocViews:
          Microarray,   
          GraphAndNetwork
 Imports: 
-    RCy3,
     viridisLite,
     STRINGdb,
     Biobase,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,8 @@ Depends: R (>= 4.2.0),
          matrixcalc
 Remotes: 
 	 stan-dev/cmdstanr,
-	 jnpaulson/pandaR 
+	 jnpaulson/pandaR, 
+	 cytoscape/RCy3
 biocViews:
 	 NetworkInference,
 	 Network,


### PR DESCRIPTION
Bioconductor version of imported package RCy3 depends on defunct package uchardet. Fixed this by switching to the dev version of RCy3 (GitHub repo cytoscape/RCy3).