### PR TITLE
Converted factor to character in network for plotting

### DIFF
--- a/R/BLOBFISH.R
+++ b/R/BLOBFISH.R
@@ -595,6 +595,11 @@ PlotNetwork <- function(network, genesOfInterest,
                         tfColor = "blue", nodeSize = 1,
                         edgeWidth = 0.5, vertexLabels = NA, vertexLabelSize = 0.7,
                         vertexLabelOffset = 0.5, layoutBipartite = TRUE, geneColorMapping = NULL){
+  
+  # Convert from factor to character.
+  network$tf <- as.character(network$tf)
+  network$gene <- as.character(network$gene)
+  
   # Set the node attributes.
   uniqueNodes <- unique(c(network$tf, network$gene))
   nodeAttrs <- data.frame(node = uniqueNodes,


### PR DESCRIPTION
This patch is tied to LIONESS-PANDA issue #334. There was an issue when plotting BLOBFISH outputs because the output TF column was a factor. The fix converts all columns to characters.