### PR TITLE
Added option not to compute coexpression matrix in SEAHORSE

### DIFF
--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -22,6 +22,7 @@
 #'                               Types can be either "numeric" or "categorical" 
 #' @param pathways : a list of pathways (e.g. KEGG, GO, Reactome etc. 
 #'                   downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)
+#' @param compute_cor : Whether or not to compute the correlation matrix. Default is TRUE.
 #' Outputs:
 #' @return results    : a list containing three objects
 #'         results$coexpression: a gene x gene Pearson correlation matrix.
@@ -51,7 +52,7 @@
 #' results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways)
 #'  
 #' @export
-seahorse <- function(expression, phenotype, phenotype_dictionary, pathways){
+seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, compute_cor = TRUE){
   if (!requireNamespace("fgsea", quietly = TRUE)) {
     stop("Package 'fgsea' is required but not installed.")
   }
@@ -60,7 +61,10 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways){
   results = list()
   
   # Compute coexpression of genes
-  results$coexpression = cor(t(expression), use="pairwise.complete.obs")
+  results$coexpression <- NA
+  if(compute_cor == TRUE){
+    results$coexpression = cor(t(expression), use="pairwise.complete.obs")
+  }
   
   # Compute association of gene expression with phenotypes and run GSEA
   results$phenotype_association = list()

--- a/man/seahorse.Rd
+++ b/man/seahorse.Rd
@@ -14,7 +14,13 @@ Description:
               for a numerical phenotype is Pearson correlation and
               for a categorical phenotype is the p-value of an ANOVA test}
 \usage{
-seahorse(expression, phenotype, phenotype_dictionary, pathways)
+seahorse(
+  expression,
+  phenotype,
+  phenotype_dictionary,
+  pathways,
+  compute_cor = TRUE
+)
 }
 \arguments{
 \item{expression}{: gene expression matrix (normalized, and filtered) 
@@ -31,7 +37,9 @@ containing type of each phenotype.
 Types can be either "numeric" or "categorical"}
 
 \item{pathways}{: a list of pathways (e.g. KEGG, GO, Reactome etc. 
-                  downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)
+downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)}
+
+\item{compute_cor}{: Whether or not to compute the correlation matrix. Default is TRUE.
 Outputs:}
 }
 \value{

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -33,4 +33,17 @@ test_that("seahorse function works", {
   expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
   # Check that phenotype names appear in sub-lists
   expect_true(all(c("sex", "height") %in% names(results$GSEA)))
+  
+  # Run seahorse without correlation matrix
+  results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                      compute_cor = FALSE)
+  
+  # Verify structure
+  expect_type(results, "list")
+  expect_true(length(results) > 0)
+  # Check that results contain expected top-level keys
+  expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
+  # Check that phenotype names appear in sub-lists
+  expect_true(all(c("sex", "height") %in% names(results$GSEA)))
+  expect_true(is.na(results$coexpression))
   })


### PR DESCRIPTION
Added a user option not to compute coexpression matrix in SEAHORSE (which can be computationally intensive)