### PR TITLE
Removed internal seed setting

### DIFF
--- a/R/BLOBFISH.R
+++ b/R/BLOBFISH.R
@@ -80,9 +80,6 @@ RunBLOBFISH <- function(geneSet, networks, alpha, hopConstraint, nullDistributio
 GenerateNullPANDADistribution <- function(ppiFile, motifFile, sampSize = 20,
                                           numberOfPandas = 10){
   
-  # Set the seed.
-  set.seed(1)
-  
   # Read the motif.
   motif <- utils::read.table(motifFile, sep = "\t")
   ppi <- utils::read.table(ppiFile, sep = "\t")


### PR DESCRIPTION
Internally setting the seed leads to reproducible behavior but is a problem if the user wants to split the generation of null PANDA networks into chunks and then paste them (which can be more efficient). We therefore allow the user to set the seed as needed for their application.