### PR TITLE
Added p-value adjustment to SEAHORSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: netZooR
 Type: Package
 Title: A Menagerie of Methods for the Inference and Analysis of Gene Regulatory Networks
-Version: 1.6.3
+Version: 1.7.0
 Date: 2026-02-19
 Authors@R: c(person("Tara", "Eicher",
                         email = "teicher@hsph.harvard.edu", role = c("aut"), comment = c(ORCID = "0000-0003-1809-4458")),

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -29,6 +29,8 @@
 #' @param transform_expression : Whether or not to transform gene expression data into logCPM.
 #' This parameter is only used for the "linear" association method. Use if your data are raw RNA-seq
 #' counts. Default is TRUE.
+#' @param pval_adj_method Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
+#' "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".
 #' Outputs:
 #' @return results    : a list containing three objects
 #'         results$coexpression: a gene x gene Pearson correlation matrix.
@@ -59,11 +61,19 @@
 #'  
 #' @export
 seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, compute_cor = TRUE,
-                     assoc_method = "pearson", transform_expression = TRUE){
+                     assoc_method = "pearson", transform_expression = TRUE, pval_adj_method = "none"){
   if (!requireNamespace("fgsea", quietly = TRUE)) {
     stop("Package 'fgsea' is required but not installed.")
   }
+  if (!requireNamespace("stats", quietly = TRUE)) {
+    stop("Package 'stats' is required but not installed.")
+  }
   set.seed(0)
+  
+  # Return an error if pval_adj_method is not an accepted method.
+  if(!(pval_adj_method %in% stats::p.adjust.methods)){
+    stop(paste(pval_adj_method, "is not a valid method for stats::p.adjust()."))
+  }
   
   # Check that association method is valid.
   if(!assoc_method %in% c("pearson", "spearman", "kendall", "linear")){
@@ -86,13 +96,14 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, comp
   if(assoc_method %in% c("pearson", "spearman", "kendall")){
     corr <- computeCorrelations(expression = expression, phenotype = phenotype,
                                    pathways = pathways, phenotype_dictionary = phenotype_dictionary,
-                                   method = assoc_method)
+                                   method = assoc_method, pval_adj_method = pval_adj_method)
     results$phenotype_association <- corr$pheno
     results$GSEA <- corr$gsea
   }else{
     linReg <- computeLinearRegression(expression = expression, phenotype = phenotype,
                                        pathways = pathways, phenotype_dictionary = phenotype_dictionary,
-                                       transform_expression = transform_expression)
+                                       transform_expression = transform_expression,
+                                      pval_adj_method = pval_adj_method)
     results$phenotype_association <- linReg$pheno
     results$GSEA <- linReg$gsea
   }
@@ -115,10 +126,12 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, comp
 #' @param pathways : a list of pathways (e.g. KEGG, GO, Reactome etc. 
 #'                   downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)
 #' @param transform_expression : Whether or not to transform gene expression data into logCPM.
+#' @param pval_adj_method Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
+#' "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".
 #' This parameter is only used for the "linear" association method. Use if your data are raw RNA-seq
 #' counts. Default is TRUE.
 computeLinearRegression <- function(expression, phenotype, phenotype_dictionary, pathways,
-                                    transform_expression){
+                                    transform_expression, pval_adj_method){
   
   # Initialize output.
   phenoAssoc <- list
@@ -148,8 +161,8 @@ computeLinearRegression <- function(expression, phenotype, phenotype_dictionary,
   # Format p-values as a list for all covariates.
   p_list <- lapply(colnames(p_vals), function(c){
     p <- p_vals[,c]
-    names(p) <- rownames(p_vals)
-    return(p)
+    padj <- stats::p.adjust(p_vals[,c], method = pval_adj_method)
+    return(data.frame(stat = p, padj = padj, row.names = rownames(p_vals)))
   })
   names(p_list) <- colnames(p_vals)
 
@@ -183,7 +196,10 @@ computeLinearRegression <- function(expression, phenotype, phenotype_dictionary,
 #' @param pathways : a list of pathways (e.g. KEGG, GO, Reactome etc. 
 #'                   downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)
 #' @param method : One of "pearson", "spearman", or "kendall".
-computeCorrelations <- function(expression, phenotype, phenotype_dictionary, pathways, method){
+#' @param pval_adj_method Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
+#' "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".
+computeCorrelations <- function(expression, phenotype, phenotype_dictionary, pathways, method,
+                                pval_adj_method){
   phenoAssoc <- list()
   gsea <- list()
   for (i in 1:ncol(phenotype)){
@@ -192,8 +208,14 @@ computeCorrelations <- function(expression, phenotype, phenotype_dictionary, pat
     
     if (phenotype_dictionary[i] == "numeric"){
       output_seahorse = gsea_numeric(expression, pheno, pathways, method = method)
-    }else {output_seahorse = gsea_categorical(expression, pheno, pathways)}
-    phenoAssoc[[pheno_name]] = output_seahorse$cor
+      output_seahorse_padj <- rep("NA", length(output_seahorse$cor))
+    }else {
+      output_seahorse = gsea_categorical(expression, pheno, pathways)
+      output_seahorse_padj <- stats::p.adjust(output_seahorse$cor, method = pval_adj_method)
+    }
+    phenoAssoc[[pheno_name]] = data.frame(stat = output_seahorse$cor,
+                                          padj = output_seahorse_padj,
+                                          row.names = names(output_seahorse$cor))
     gsea[[pheno_name]] = output_seahorse$GSEA
   }
   return(list(pheno = phenoAssoc, gsea = gsea))

--- a/man/computeCorrelations.Rd
+++ b/man/computeCorrelations.Rd
@@ -10,7 +10,8 @@ computeCorrelations(
   phenotype,
   phenotype_dictionary,
   pathways,
-  method
+  method,
+  pval_adj_method
 )
 }
 \arguments{
@@ -31,6 +32,9 @@ Types can be either "numeric" or "categorical"}
 downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)}
 
 \item{method}{: One of "pearson", "spearman", or "kendall".}
+
+\item{pval_adj_method}{Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
+"holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".}
 }
 \description{
 Computes correlation for numeric phenotypes and ANOVA for categorical

--- a/man/computeLinearRegression.Rd
+++ b/man/computeLinearRegression.Rd
@@ -11,7 +11,8 @@ computeLinearRegression(
   phenotype,
   phenotype_dictionary,
   pathways,
-  transform_expression
+  transform_expression,
+  pval_adj_method
 )
 }
 \arguments{
@@ -31,7 +32,10 @@ Types can be either "numeric" or "categorical"}
 \item{pathways}{: a list of pathways (e.g. KEGG, GO, Reactome etc. 
 downloaded from http://www.gsea-msigdb.org/gsea/msigdb/human/collections.jsp)}
 
-\item{transform_expression}{: Whether or not to transform gene expression data into logCPM.
+\item{transform_expression}{: Whether or not to transform gene expression data into logCPM.}
+
+\item{pval_adj_method}{Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
+"holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".
 This parameter is only used for the "linear" association method. Use if your data are raw RNA-seq
 counts. Default is TRUE.}
 }

--- a/man/seahorse.Rd
+++ b/man/seahorse.Rd
@@ -18,7 +18,8 @@ seahorse(
   pathways,
   compute_cor = TRUE,
   assoc_method = "pearson",
-  transform_expression = TRUE
+  transform_expression = TRUE,
+  pval_adj_method = "none"
 )
 }
 \arguments{
@@ -49,7 +50,10 @@ for each coefficient.}
 
 \item{transform_expression}{: Whether or not to transform gene expression data into logCPM.
 This parameter is only used for the "linear" association method. Use if your data are raw RNA-seq
-counts. Default is TRUE.
+counts. Default is TRUE.}
+
+\item{pval_adj_method}{Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
+"holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".
 Outputs:}
 }
 \value{

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -23,6 +23,12 @@ test_that("seahorse function works", {
   pathways$pathway2 = sample(rownames(expression_data), 30)
   pathways$pathway3 = sample(rownames(expression_data), 70)
   
+  # Check that seahorse returns an error if the p-value adjustment method
+  # is invalid.
+  expect_error(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                        pval_adj_method = "myCoolAdjustmentMethod"),
+               "myCoolAdjustmentMethod is not a valid method for stats::p.adjust().")
+  
   # Run seahorse
   results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways)
 
@@ -46,7 +52,42 @@ test_that("seahorse function works", {
   expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
   # Check that phenotype names appear in sub-lists
   expect_true(all(c("sex", "height") %in% names(results$GSEA)))
+  expect_equal(results$phenotype_association$sex$stat, results$phenotype_association$sex$padj)
+  expect_equal(results$phenotype_association$height$padj, rep("NA", length(results$phenotype_association$height$padj)))
   expect_true(is.na(results$coexpression))
+  
+  # Run seahorse with bonferroni correction
+  results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                      compute_cor = FALSE, pval_adj_method = "bonferroni")
+  
+  # Verify structure
+  expect_type(results, "list")
+  expect_true(length(results) > 0)
+  # Check that results contain expected top-level keys
+  expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
+  # Check that phenotype names appear in sub-lists
+  expect_true(all(c("sex", "height") %in% names(results$GSEA)))
+  expect_equal(stats::p.adjust(results$phenotype_association$sex$stat, method = "bonferroni"), 
+               results$phenotype_association$sex$padj)
+  expect_equal(results$phenotype_association$height$padj, rep("NA", length(results$phenotype_association$height$padj)))
+  expect_true(is.na(results$coexpression))
+  
+  # Run seahorse with fdr correction
+  results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                      compute_cor = FALSE, pval_adj_method = "fdr")
+  
+  # Verify structure
+  expect_type(results, "list")
+  expect_true(length(results) > 0)
+  # Check that results contain expected top-level keys
+  expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
+  # Check that phenotype names appear in sub-lists
+  expect_true(all(c("sex", "height") %in% names(results$GSEA)))
+  expect_equal(stats::p.adjust(results$phenotype_association$sex$stat, method = "fdr"), 
+               results$phenotype_association$sex$padj)
+  expect_equal(results$phenotype_association$height$padj, rep("NA", length(results$phenotype_association$height$padj)))
+  expect_true(is.na(results$coexpression))
+  
   
   # Run SEAHORSE with linear regression.
   results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
@@ -58,7 +99,43 @@ test_that("seahorse function works", {
   expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
   # Check that phenotype names appear in sub-lists
   expect_true(all(c("(Intercept)", "sexmale", "height") %in% names(results$GSEA)))
+  expect_equal(results$phenotype_association$sexmale$stat, results$phenotype_association$sexmale$padj)
+  expect_equal(results$phenotype_association$height$stat, results$phenotype_association$height$padj)
   expect_true(is.na(results$coexpression))
+  
+  # Run SEAHORSE with linear regression and Bonferroni adjustment
+  results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                      compute_cor = FALSE, assoc_method = "linear",
+                      pval_adj_method = "bonferroni")
+  # Verify structure
+  expect_type(results, "list")
+  expect_true(length(results) > 0)
+  # Check that results contain expected top-level keys
+  expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
+  # Check that phenotype names appear in sub-lists
+  expect_true(all(c("(Intercept)", "sexmale", "height") %in% names(results$GSEA)))
+  expect_equal(stats::p.adjust(results$phenotype_association$sexmale$stat, method = "bonferroni"),
+               results$phenotype_association$sexmale$padj)
+  expect_equal(stats::p.adjust(results$phenotype_association$height$stat, method = "bonferroni"),
+               results$phenotype_association$height$padj)
+  expect_true(is.na(results$coexpression))
+  
+  # Run SEAHORSE with linear regression and FDR adjustment
+  results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                      compute_cor = FALSE, assoc_method = "linear", pval_adj_method = "fdr")
+  # Verify structure
+  expect_type(results, "list")
+  expect_true(length(results) > 0)
+  # Check that results contain expected top-level keys
+  expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
+  # Check that phenotype names appear in sub-lists
+  expect_true(all(c("(Intercept)", "sexmale", "height") %in% names(results$GSEA)))
+  expect_equal(stats::p.adjust(results$phenotype_association$sexmale$stat, method = "fdr"),
+               results$phenotype_association$sexmale$padj)
+  expect_equal(stats::p.adjust(results$phenotype_association$height$stat, method = "fdr"),
+               results$phenotype_association$height$padj)
+  expect_true(is.na(results$coexpression))
+  
   
   # Run SEAHORSE with linear regression and the correlation matrix.
   results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -123,6 +123,19 @@ test_that("seahorse function works", {
   # Run SEAHORSE with linear regression and FDR adjustment
   results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
                       compute_cor = FALSE, assoc_method = "linear", pval_adj_method = "fdr")
+  # Verify structure
+  expect_type(results, "list")
+  expect_true(length(results) > 0)
+  # Check that results contain expected top-level keys
+  expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
+  # Check that phenotype names appear in sub-lists
+  expect_true(all(c("(Intercept)", "sexmale", "height") %in% names(results$GSEA)))
+  expect_equal(stats::p.adjust(results$phenotype_association$sexmale$stat, method = "fdr"),
+               results$phenotype_association$sexmale$padj)
+  expect_equal(stats::p.adjust(results$phenotype_association$height$stat, method = "fdr"),
+               results$phenotype_association$height$padj)
+  expect_true(is.na(results$coexpression))
+  
   # Check that SEAHORSE runs with linear regression and a malformed column name.
   phenotype_data_mal <- phenotype_data
   colnames(phenotype_data_mal) <- c("?sex", "height in inches")
@@ -153,12 +166,7 @@ test_that("seahorse function works", {
   expect_true(all(c("coexpression", "phenotype_association", "GSEA") %in% names(results)))
   # Check that phenotype names appear in sub-lists
   expect_true(all(c("(Intercept)", "sexmale", "height") %in% names(results$GSEA)))
-  expect_equal(stats::p.adjust(results$phenotype_association$sexmale$stat, method = "fdr"),
-               results$phenotype_association$sexmale$padj)
-  expect_equal(stats::p.adjust(results$phenotype_association$height$stat, method = "fdr"),
-               results$phenotype_association$height$padj)
-  expect_true(is.na(results$coexpression))
-  
+  expect_true(all(is.na(results$coexpression)))
   
   # Run SEAHORSE with linear regression and the correlation matrix.
   results <- seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,


### PR DESCRIPTION
Modification performs p-value adjustment for any method permitted by `stats::p.adjust()`. For correlation-based SEAHORSE runs, adjustment is performed independently on each categorical variable. For regression-based SEAHORSE runs, adjustment is performed independently on each variable. 

The object returned by running SEAHORSE changes such that `result$phenotype_association` is no longer a named list of vectors but a named list of data frames, where each data frame has the columns "stat" and "padj". If pval_adj_method = "none", the "padj" column will be identical to the "stat" column. For correlation-based SEAHORSE runs with numeric variables, correlation rather than p-value is returned in the "stat" column, and the "padj" column contains NA values.