### PR TITLE
SEAHORSE: Removed extra FFH check and test cases

### DIFF
--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -709,33 +709,10 @@ phenotype_chisq <- function(phenotype, phenotypesToCompare, phenotypeType){
     grpCounts <- table(phenotype, phen)
   })
   names(allPhenoPairTables) <- colnames(phenotypesToCompare)
-
-  # Check which phenotype pair tables have an entry below the cutoff for Chi-square.
-  ffhCutoff <- 5
-  isBelowCutoff <- unlist(lapply(allPhenoPairTables, function(tbl){
-    anyBelow <- FALSE
-    if(min(tbl) < ffhCutoff){
-      anyBelow <- TRUE
-    }
-    return(anyBelow)
-  }))
-  names(isBelowCutoff) <- colnames(phenotypesToCompare)
-  
-  # If one of the groups listed in the contingency table has < 5 samples, run FFH test instead.
-  # Separate phenotypes to compare into those which require an FFH test and
-  # those which can use a chi-square test.
-  phenotypesLess <- as.data.frame(phenotypesToCompare[,which(isBelowCutoff == TRUE)])
-  colnames(phenotypesLess) <- colnames(phenotypesToCompare)[which(isBelowCutoff == TRUE)]
-  phenotypesNotLess <- as.data.frame(phenotypesToCompare[,which(isBelowCutoff == FALSE)])
-  colnames(phenotypesNotLess) <- colnames(phenotypesToCompare)[which(isBelowCutoff == FALSE)]
-  
-  # Do an FFH test where necessary.
-  corResLess <- phenotype_ffs(allPhenoPairTables[which(isBelowCutoff == TRUE)])
   
   # Do a chi-square test everywhere else.
-  # Run the comparisons one at a time because FFH cannot be scaled.
-  notLessTables <- allPhenoPairTables[which(isBelowCutoff == FALSE)]
-  chisqRes <- lapply(notLessTables, function(chisqTable) {
+  # Run the comparisons one at a time because Chi-square and FFH cannot be scaled.
+  chisqRes <- lapply(allPhenoPairTables, function(chisqTable) {
     
     # Run the test. If a warning is thrown, switch to FFH.
     type <- "Chi-square"
@@ -768,15 +745,15 @@ phenotype_chisq <- function(phenotype, phenotypesToCompare, phenotypeType){
   corResNotLessFull <- data.frame(cor = chisqP,
                               V = cramerV,
                               testType = testType,
-                              row.names = colnames(phenotypesNotLess))
+                              row.names = colnames(phenotypesToCompare))
   
   # Run FFS where warning was issued.
   corResNotLess <- corResNotLessFull[which(corResNotLessFull$testType == "Chi-square"),]
-  switchedTables <- notLessTables[which(corResNotLessFull$testType == "FFH")]
+  switchedTables <- allPhenoPairTables[which(corResNotLessFull$testType == "FFH")]
   corResSwitched <- phenotype_ffs(switchedTables)
 
   # Bind together the results from the FFH and Chi-Square tests.
-  corRes <- rbind(corResLess, corResNotLess, corResSwitched)
+  corRes <- rbind(corResNotLess, corResSwitched)
   corRes <- corRes[colnames(phenotypesToCompare),]
 
   return(corRes)

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -67,11 +67,10 @@ test_that("seahorse function works", {
   expect_true(all(c("sex", "height", "group") %in% colnames(results$phenocor$padj)))
   
   # Run seahorse to test both FFH and Chi-square tests and ANOVA, t-test, and correlation.
-  # We expect that "smoke" will trigger FFH in all except sex because true counts < 5,
-  # "sex" will trigger FFH in "group" because true counts < 5,
-  # "group" will trigger FFH in "rare group" because true counts < 5,
-  # and "group" will trigger FFH in "rare group" because EXPECTED (not true) counts < 5.
-  # and "grade" will trigger FFH in "rare group" because true counts < 5.
+  # We expect that "smoke" will trigger FFH in all except sex because EXPECTED counts < 5,
+  # "group" will trigger FFH in "rare group" because EXPECTED counts < 5,
+  # and "group" will trigger FFH in "rare group" because EXPECTED counts < 5.
+  # and "grade" will trigger FFH in "rare group" because EXPECTED counts < 5.
   # All other comparisons should trigger Chi-square tests.
   phenotype_data_2 <- do.call(rbind, rep(list(phenotype_data), 10))
   phenotype_data_2$smoke = c(rep("No", 90), rep("Yes", 10))
@@ -108,7 +107,6 @@ test_that("seahorse function works", {
   expect_true(all(!is.na(results$phenocor$stat["grade", "rare_group"])))
   # FFH specifically
   expect_true(all(is.na(results$phenocor$cramerV["smoke", c("group", "grade", "rare_group")])))
-  expect_true(all(is.na(results$phenocor$cramerV["sex", "group"])))
   expect_true(all(is.na(results$phenocor$cramerV["group", c("grade", "rare_group")])))
   expect_true(all(is.na(results$phenocor$cramerV["grade", "rare_group"])))
   expect_equal(results$phenocor$stat["smoke", c("group", "grade", "rare_group")],
@@ -120,17 +118,18 @@ test_that("seahorse function works", {
   expect_equal(results$phenocor$stat["grade", "rare_group"],
                results$phenocor$padj["grade", "rare_group"])
   expect_all_equal(results$phenocor$testType["smoke", c("group", "grade", "rare_group")], "FFH")
-  expect_all_equal(results$phenocor$testType["sex", "group"], "FFH")
   expect_all_equal(results$phenocor$testType["group", c("grade", "rare_group")], "FFH")
   expect_all_equal(results$phenocor$testType["grade", "rare_group"], "FFH")
   # Chi-square specifically
   expect_true(all(!is.na(results$phenocor$cramerV["smoke", "sex"])))
+  expect_true(all(!is.na(results$phenocor$cramerV["sex", "group"])))
   expect_true(all(!is.na(results$phenocor$cramerV["sex", c("grade", "rare_group")])))
   expect_equal(results$phenocor$stat["smoke", "sex"],
                results$phenocor$padj["smoke", "sex"])
   expect_equal(results$phenocor$stat["sex", c("grade", "rare_group")],
                results$phenocor$padj["sex", c("grade", "rare_group")])
   expect_all_equal(results$phenocor$testType["smoke", "sex"], "Chi-square")
+  expect_all_equal(results$phenocor$testType["sex", "group"], "Chi-square")
   expect_all_equal(results$phenocor$testType["sex", c("grade", "rare_group")], "Chi-square")
   # Ensure that statistics are calculated as expected (ANOVA)
   expect_true(all(!is.na(results$phenocor$stat["group", "height"])))
@@ -186,7 +185,6 @@ test_that("seahorse function works", {
   expect_true(all(!is.na(results$phenocor$stat["grade", "rare_group"])))
   # FFH specifically
   expect_true(all(is.na(results$phenocor$cramerV["smoke", c("group", "grade", "rare_group")])))
-  expect_true(all(is.na(results$phenocor$cramerV["sex", "group"])))
   expect_true(all(is.na(results$phenocor$cramerV["group", c("grade", "rare_group")])))
   expect_true(all(is.na(results$phenocor$cramerV["grade", "rare_group"])))
   expect_equal(p.adjust(results$phenocor$stat["smoke", c("group", "grade", "rare_group")], method = "fdr"),
@@ -198,16 +196,17 @@ test_that("seahorse function works", {
   expect_equal(p.adjust(results$phenocor$stat["grade", "rare_group"], method = "fdr"),
                results$phenocor$padj["grade", "rare_group"])
   expect_all_equal(results$phenocor$testType["smoke", c("group", "grade", "rare_group")], "FFH")
-  expect_all_equal(results$phenocor$testType["sex", "group"], "FFH")
   expect_all_equal(results$phenocor$testType["group", c("grade", "rare_group")], "FFH")
   expect_all_equal(results$phenocor$testType["grade", "rare_group"], "FFH")
   # Chi-square specifically
   expect_true(all(!is.na(results$phenocor$cramerV["smoke", "sex"])))
+  expect_all_equal(results$phenocor$testType["sex", "group"], "Chi-square")
+  expect_true(all(!is.na(results$phenocor$cramerV["sex", "group"])))
   expect_true(all(!is.na(results$phenocor$cramerV["sex", c("grade", "rare_group")])))
   expect_equal(p.adjust(results$phenocor$stat["smoke", "sex"], method = "fdr"),
                results$phenocor$padj["smoke", "sex"])
-  expect_equal(p.adjust(results$phenocor$stat["sex", c("grade", "rare_group")], method = "fdr"),
-               results$phenocor$padj["sex", c("grade", "rare_group")])
+  expect_equal(p.adjust(results$phenocor$stat["sex", c("group", "grade", "rare_group")], method = "fdr"),
+               results$phenocor$padj["sex", c("group", "grade", "rare_group")])
   expect_all_equal(results$phenocor$testType["smoke", "sex"], "Chi-square")
   expect_all_equal(results$phenocor$testType["sex", c("grade", "rare_group")], "Chi-square")
   # Ensure that statistics are calculated as expected (ANOVA)


### PR DESCRIPTION
We now attempt to run the Chi-square test for all categorical phenotype pairs unless a warning is issued that estimates are incorrect. This handles the case where observed counts <= 5 but expected counts > 5, addressing issue https://github.com/netZoo/netZooR/issues/420.