### PR TITLE
Added SEAHORSE Edge Cases

### DIFF
--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -115,7 +115,7 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, comp
     phenoName <- colnames(phenotype)[i]
     
     # Check that nominal have more than 2 levels.
-    levels <- unique(pheno)
+    levels <- unique(pheno[which(!is.na(pheno))])
     if(dictType == "nominal" && length(levels) <= 2){
       stop(paste("Phenotype", phenoName, "set to nominal but has 2 levels or fewer."))
     }

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -32,6 +32,7 @@
 #' @param pval_adj_method Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
 #' "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".
 #' @param usage_report_file Location where the usage report should be stored. Must be RDS format.
+#' @param verbose Whether or not to print statements notifying user of run status.
 #' Outputs:
 #' @return results    : a list containing three objects
 #'         results$coexpression: a gene x gene correlation matrix.
@@ -64,7 +65,7 @@
 seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, compute_gene_cor = TRUE,
                      compute_phenotype_cor = TRUE,
                      assoc_method = "spearman", pval_adj_method = "none",
-                     usage_report_file = NULL){
+                     usage_report_file = NULL, verbose = FALSE){
   
   # Check packages.
   if (!requireNamespace("fgsea", quietly = TRUE)) {
@@ -149,12 +150,24 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, comp
   results$coexpression <- NA
   if(is.null(usage_report_file)){
     if(compute_gene_cor == TRUE){
+      if(verbose == TRUE){
+        print("Running gene co-expression")
+      }
       results$coexpression = cor(t(expression), use="pairwise.complete.obs")
+      if(verbose == TRUE){
+        print("Gene co-expression complete")
+      }
     }
   }else{
     if(compute_gene_cor == TRUE){
       usageGeneGene <- peakRAM::peakRAM({
-        results$coexpression = cor(t(expression), use="pairwise.complete.obs") 
+        if(verbose == TRUE){
+          print("Running gene co-expression")
+        }
+        results$coexpression = cor(t(expression), use="pairwise.complete.obs")
+        if(verbose == TRUE){
+          print("Gene co-expression complete")
+        }
       })
     }
   }
@@ -164,21 +177,36 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, comp
   results$phenocor <- NA
   if(is.null(usage_report_file)){
     if(compute_phenotype_cor == TRUE){
+      if(verbose == TRUE){
+        print("Running phenotype associations")
+      }
       results$phenocor = computePhenotypeCorrelations(phenotype = phenotype,
                                                       phenotype_dictionary = phenotype_dictionary,
                                                       method = assoc_method, pval_adj_method = pval_adj_method)
+      if(verbose == TRUE){
+        print("Phenotype associations complete")
+      }
     }
   }else{
     if(compute_phenotype_cor == TRUE){
       usagePhenPhen <- peakRAM::peakRAM({
+        if(verbose == TRUE){
+          print("Running phenotype associations")
+        }
         results$phenocor = computePhenotypeCorrelations(phenotype = phenotype,
                                                         phenotype_dictionary = phenotype_dictionary,
                                                         method = assoc_method, pval_adj_method = pval_adj_method)
+        if(verbose == TRUE){
+          print("Phenotype associations complete")
+        }
       })
     } 
   }
   
   # Compute association of gene expression with phenotypes and run GSEA
+  if(verbose == TRUE){
+    print("Running gene-phenotype associations")
+  }
   usagePhenGene <- NA
   results$phenotype_association = list()
   results$GSEA = list()
@@ -212,6 +240,9 @@ seahorse <- function(expression, phenotype, phenotype_dictionary, pathways, comp
         results$GSEA <- linReg$gsea
       }
     })
+  }
+  if(verbose == TRUE){
+    print("Gene-phenotype associations complete")
   }
   
   # Save the results to a usage file.
@@ -545,6 +576,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
         output_seahorse_con <- phenotype_ttest(phenotype = pheno, 
                                               phenotypesToCompare = phenoCon, 
                                               phenotypeType = phenoType)
+        str(output_seahorse_con)
         output_seahorse_padj_con <- stats::p.adjust(output_seahorse_con$cor, method = pval_adj_method)
       }
       
@@ -586,6 +618,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
         output_seahorse_con <- phenotype_anova(phenotype = pheno, 
                                               phenotypesToCompare = phenoCon, 
                                               phenotypeType = phenoType)
+        str(output_seahorse_con)
         output_seahorse_padj_con <- stats::p.adjust(output_seahorse_con$cor, method = pval_adj_method)
       }
       
@@ -792,11 +825,27 @@ phenotype_anova <- function(phenotype, phenotypesToCompare, phenotypeType){
   # Case 2 - the phenotype is numeric and the phenotypes to compare are nominal.
   if(phenotypeType == "nominal"){
     phenotype_vector = factor(as.character(phenotype))
-    cor <- unlist(apply(phenotypesToCompare, MARGIN=2, function(x){anova(lm(as.numeric(as.character(x))~phenotype_vector))$`Pr(>F)`[1]}))
+    cor <- unlist(apply(phenotypesToCompare, MARGIN=2, function(x){
+      results <- NA
+      names(results) <- colnames(phenotype_vector)
+      tryCatch({
+        results <- anova(lm(as.numeric(as.character(x))~phenotype_vector))$`Pr(>F)`[1]
+      }, error = function(cond){
+        warning("In this phenotype pair, all continuous values are missing for one phenotype level - NA result will be returned")
+      })
+      return(results)
+    }))
   }else{
     cor <- unlist(lapply(1:ncol(phenotypesToCompare), function(i){
+      results <- NA
+      names(results) <- colnames(phenotype_vector)
       phenotype_vector <- factor(as.character(phenotypesToCompare[,i]))
-      return(anova(lm(as.numeric(as.character(phenotype))~phenotype_vector))$`Pr(>F)`[1])
+      tryCatch({
+        results <- anova(lm(as.numeric(as.character(phenotype))~phenotype_vector))$`Pr(>F)`[1]
+      }, error = function(cond){
+        warning("In this phenotype pair, all continuous values are missing for one phenotype level - NA result will be returned")
+      })
+      return(results)
     }))
   }
     

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -476,32 +476,40 @@ gsea_dichotomous <- function(expression, pheno, pathways){
   hasVal <- which(!is.na(phenotype_vector))
   phenotype_vector <- phenotype_vector[hasVal]
   expression <- expression[,hasVal]
-  design <- model.matrix(~ phenotype_vector)
-  fit <- limma::lmFit(object = expression, design = design)
   
-  # Compute empirical Bayes statistics.
-  bayes <- limma::eBayes(fit = fit)
-  
-  coef_to_test <- setdiff(colnames(design), "(Intercept)")
-  t_res <- limma::topTable(bayes, coef = coef_to_test, number = Inf, sort.by = "none")
-  
-  # Format p-values as a list for all covariates.
-  p <- t_res[,"P.Value"]
-  t <- t_res[,"t"]
-  output_seahorse$cor <- p
-  names(output_seahorse$cor) <- rownames(t_res)
-  names(t) <- rownames(t_res)
-  
-  # Run GSEA
-  fgseaRes <- NA
-  tryCatch({
-    statSorted <- sort(t, decreasing = TRUE)
-    fgseaRes <- fgsea::fgsea(pathways, statSorted, minSize=15, maxSize=500)
-  }, error = function(cond){
-    print(cond)
-  })
-  
-  output_seahorse$GSEA = fgseaRes
+  # Check that we still have multiple values. If not, return NA for this covariate.
+  output_seahorse$cor <- NA
+  output_seahorse$GSEA <- NA
+  if(length(unique(phenotype_vector)) > 1){
+    design <- model.matrix(~ phenotype_vector)
+    fit <- limma::lmFit(object = expression, design = design)
+    
+    # Compute empirical Bayes statistics.
+    bayes <- limma::eBayes(fit = fit)
+    
+    coef_to_test <- setdiff(colnames(design), "(Intercept)")
+    t_res <- limma::topTable(bayes, coef = coef_to_test, number = Inf, sort.by = "none")
+    
+    # Format p-values as a list for all covariates.
+    p <- t_res[,"P.Value"]
+    t <- t_res[,"t"]
+    output_seahorse$cor <- p
+    names(output_seahorse$cor) <- rownames(t_res)
+    names(t) <- rownames(t_res)
+    
+    # Run GSEA
+    fgseaRes <- NA
+    tryCatch({
+      statSorted <- sort(t, decreasing = TRUE)
+      fgseaRes <- fgsea::fgsea(pathways, statSorted, minSize=15, maxSize=500)
+    }, error = function(cond){
+      print(cond)
+    })
+    
+    output_seahorse$GSEA = fgseaRes
+  }else{
+    warning("Phenotype has only one level. Returning NA for all gene associations.")
+  }
   
   return(output_seahorse)
 }
@@ -894,22 +902,41 @@ phenotype_ttest <- function(phenotype, phenotypesToCompare, phenotypeType){
     # Check that thresholds are met.
     whichLevel1 <- length(which(phenotype_vector == levels[1]))
     whichLevel2 <- length(which(phenotype_vector == levels[2]))
-    meetsThreshold <- colSums(!is.na(group1)) >= 2 & colSums(!is.na(group2)) >= 2
+    cor <- NA
     
-    # Initialize result to NA.
-    cor <- rep(NA, ncol(group1))
-    names(cor) <- colnames(group1)
-    
-    # Only compute correlations if both levels are represented in the phenotype vector.
-    if(whichLevel1 > 0 && whichLevel2 > 0 && length(which(meetsThreshold == TRUE)) > 0){
-      # Compute t-test where thresholds are met.
-      tresValid <- matrixTests::col_t_welch(
-        group1[, meetsThreshold, drop = FALSE],
-        group2[, meetsThreshold, drop = FALSE]
-      )
+    if(length(dim(group1)) >= 2 || length(dim(group2)) >= 2){
+      meetsThreshold <- colSums(!is.na(group1)) >= 2 & colSums(!is.na(group2)) >= 2
       
-      # Compute remaining t-tests.
-      cor[meetsThreshold] <- tresValid$pvalue
+      # Initialize result to NA.
+      cor <- rep(NA, ncol(group1))
+      names(cor) <- colnames(group1)
+      
+      # Only compute correlations if both levels are represented in the phenotype vector.
+      if(whichLevel1 > 0 && whichLevel2 > 0 && length(which(meetsThreshold == TRUE)) > 0){
+        # Compute t-test where thresholds are met.
+        tresValid <- matrixTests::col_t_welch(
+          group1[, meetsThreshold, drop = FALSE],
+          group2[, meetsThreshold, drop = FALSE]
+        )
+        
+        # Compute remaining t-tests.
+        cor[meetsThreshold] <- tresValid$pvalue
+      }
+    }else{
+      meetsThreshold <- sum(!is.na(group1)) >= 2 & sum(!is.na(group2)) >= 2
+      
+      # Initialize result to NA.
+      names(cor) <- names(group1)
+      
+      # Only compute correlations if both levels are represented in the phenotype vector.
+      if(whichLevel1 > 0 && whichLevel2 > 0 && length(which(meetsThreshold == TRUE)) > 0){
+        # Compute t-test where thresholds are met.
+        tresValid <- t.test(group1[meetsThreshold, drop = FALSE], 
+                            group2[meetsThreshold, drop = FALSE])
+        
+        # Compute remaining t-tests.
+        cor[meetsThreshold] <- tresValid$p.value
+      }
     }
     
   }else{

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -563,7 +563,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "FFH"), "cor"], method = pval_adj_method)
         output_seahorse_padj_cat[which(output_seahorse_cat$testType == "Chi-square")] <- 
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "Chi-square"), "cor"], method = pval_adj_method)
-        str(output_seahorse_cat)
       }
       
       # Do continuous phenotypes.
@@ -577,7 +576,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
         output_seahorse_con <- phenotype_ttest(phenotype = pheno, 
                                               phenotypesToCompare = phenoCon, 
                                               phenotypeType = phenoType)
-        str(output_seahorse_con)
         output_seahorse_padj_con <- stats::p.adjust(output_seahorse_con$cor, method = pval_adj_method)
       }
       
@@ -606,7 +604,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "FFH"), "cor"], method = pval_adj_method)
         output_seahorse_padj_cat[which(output_seahorse_cat$testType == "Chi-square")] <- 
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "Chi-square"), "cor"], method = pval_adj_method)
-        str(output_seahorse_cat)
       }
       
       # Do continuous phenotypes.
@@ -620,7 +617,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
         output_seahorse_con <- phenotype_anova(phenotype = pheno, 
                                               phenotypesToCompare = phenoCon, 
                                               phenotypeType = phenoType)
-        str(output_seahorse_con)
         output_seahorse_padj_con <- stats::p.adjust(output_seahorse_con$cor, method = pval_adj_method)
       }
       
@@ -645,7 +641,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
                                                     phenotypesToCompare = phenoDich, 
                                                     phenotypeType = phenoType)
         output_seahorse_padj_dich <- stats::p.adjust(output_seahorse_dich$cor, method = pval_adj_method)
-        str(output_seahorse_dich)
       }
       
       # Do nominal phenotypes.
@@ -660,7 +655,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
                                               phenotypesToCompare = phenoNom, 
                                               phenotypeType = phenoType)
         output_seahorse_padj_nom <- stats::p.adjust(output_seahorse_nom$cor, method = pval_adj_method)
-        str(output_seahorse_nom)
       }
 
       # Do continuous phenotypes.
@@ -675,7 +669,6 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
                                               phenotypesToCompare = phenoCon, 
                                             method = method)
         output_seahorse_padj_con <- rep(NA, nrow(output_seahorse_con))
-        str(output_seahorse_con)
       }
       
       # Concatenate categorical and continuous results.
@@ -899,7 +892,7 @@ phenotype_ttest <- function(phenotype, phenotypesToCompare, phenotypeType){
     names(cor) <- colnames(group1)
     
     # Only compute correlations if both levels are represented in the phenotype vector.
-    if(whichLevel1 > 0 && whichLevel2 > 0){
+    if(whichLevel1 > 0 && whichLevel2 > 0 && length(which(meetsThreshold == TRUE)) > 0){
       # Compute t-test where thresholds are met.
       tresValid <- matrixTests::col_t_welch(
         group1[, meetsThreshold, drop = FALSE],

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -752,13 +752,15 @@ phenotype_chisq <- function(phenotype, phenotypesToCompare, phenotypeType){
   # Run the comparisons one at a time because Chi-square and FFH cannot be scaled.
   chisqRes <- lapply(allPhenoPairTables, function(chisqTable) {
     
-    # Check that we have 2 or more non-zero row marginals. Only run the test if we do.
+    # Check that we have 2 or more non-zero marginals. Only run the test if we do.
     rowMarginals <- rowSums(chisqTable)
-    nonzeroMarginalCount <- length(which(rowMarginals > 0))
+    colMarginals <- colSums(chisqTable) 
+    nonzeroRowMarginalCount <- length(which(rowMarginals > 0))
+    nonzeroColMarginalCount <- length(which(colMarginals > 0))
     pval <- NA
     V <- NA
     type <- "Chi-square"
-    if(nonzeroMarginalCount > 2){
+    if(nonzeroRowMarginalCount > 2 && nonzeroColMarginalCount > 2){
       # Run the test. If a warning is thrown, switch to FFH.
       chisq <- withCallingHandlers(
         chisq.test(chisqTable),

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -354,6 +354,7 @@ computeCorrelations <- function(expression, phenotype, phenotype_dictionary, pat
   for (i in 1:ncol(phenotype)){
     pheno = phenotype[,i]
     pheno_name = colnames(phenotype)[i]
+    print(colnames(phenotype)[i])
     
     if (phenotype_dictionary[i] == "continuous"){
       output_seahorse = gsea_continuous(expression, pheno, pathways, method = method)
@@ -426,6 +427,10 @@ gsea_nominal <- function(expression, pheno, pathways){
   
   # Run the linear models.
   phenotype_vector = factor(as.character(pheno))
+  # Remove NA values.
+  hasVal <- which(!is.na(phenotype_vector))
+  phenotype_vector <- phenotype_vector[hasVal]
+  expression <- expression[,hasVal]
   design <- model.matrix(~ phenotype_vector)
   fit <- limma::lmFit(object = expression, design = design)
   
@@ -467,6 +472,10 @@ gsea_dichotomous <- function(expression, pheno, pathways){
   
   # Run the linear models.
   phenotype_vector = factor(as.character(pheno))
+  # Remove NA values.
+  hasVal <- which(!is.na(phenotype_vector))
+  phenotype_vector <- phenotype_vector[hasVal]
+  expression <- expression[,hasVal]
   design <- model.matrix(~ phenotype_vector)
   fit <- limma::lmFit(object = expression, design = design)
   

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -434,20 +434,25 @@ gsea_nominal <- function(expression, pheno, pathways){
   fit <- limma::lmFit(object = expression, design = design)
   
   # Compute empirical Bayes statistics.
-  bayes <- limma::eBayes(fit = fit)
-  
-  coef_to_test <- setdiff(colnames(design), "(Intercept)")
-  anova_res <- limma::topTable(bayes, coef = coef_to_test, number = Inf, sort.by = "none")
-  
-  # Format p-values as a list for all covariates.
-  p <- anova_res[,"P.Value"]
-  output_seahorse$cor <- p
-  names(output_seahorse$cor) <- rownames(anova_res)
-  
-  # Run GSEA
-  statSorted <- sort(-1 * log10(output_seahorse$cor), decreasing = TRUE)
-  fgseaRes <- fgsea::fgsea(pathways, statSorted, minSize=15, maxSize=500, scoreType = "pos")
-  output_seahorse$GSEA = fgseaRes
+  # If there are no residual degrees of freedom, catch it and do not return a value.
+  tryCatch({
+    bayes <- limma::eBayes(fit = fit)
+    
+    coef_to_test <- setdiff(colnames(design), "(Intercept)")
+    anova_res <- limma::topTable(bayes, coef = coef_to_test, number = Inf, sort.by = "none")
+    
+    # Format p-values as a list for all covariates.
+    p <- anova_res[,"P.Value"]
+    output_seahorse$cor <- p
+    names(output_seahorse$cor) <- rownames(anova_res)
+    
+    # Run GSEA
+    statSorted <- sort(-1 * log10(output_seahorse$cor), decreasing = TRUE)
+    fgseaRes <- fgsea::fgsea(pathways, statSorted, minSize=15, maxSize=500, scoreType = "pos")
+    output_seahorse$GSEA = fgseaRes
+  }, error = function(cond){
+    warning("Could not compute empirical Bayes statistics for this phenotypic variable. Returning empty list.")
+  })
   
   return(output_seahorse)
 }
@@ -471,6 +476,7 @@ gsea_dichotomous <- function(expression, pheno, pathways){
   
   # Run the linear models.
   phenotype_vector = factor(as.character(pheno))
+
   # Remove NA values.
   hasVal <- which(!is.na(phenotype_vector))
   phenotype_vector <- phenotype_vector[hasVal]
@@ -484,28 +490,32 @@ gsea_dichotomous <- function(expression, pheno, pathways){
     fit <- limma::lmFit(object = expression, design = design)
     
     # Compute empirical Bayes statistics.
-    bayes <- limma::eBayes(fit = fit)
-    
-    coef_to_test <- setdiff(colnames(design), "(Intercept)")
-    t_res <- limma::topTable(bayes, coef = coef_to_test, number = Inf, sort.by = "none")
-    
-    # Format p-values as a list for all covariates.
-    p <- t_res[,"P.Value"]
-    t <- t_res[,"t"]
-    output_seahorse$cor <- p
-    names(output_seahorse$cor) <- rownames(t_res)
-    names(t) <- rownames(t_res)
-    
-    # Run GSEA
-    fgseaRes <- NA
     tryCatch({
-      statSorted <- sort(t, decreasing = TRUE)
-      fgseaRes <- fgsea::fgsea(pathways, statSorted, minSize=15, maxSize=500)
+      bayes <- limma::eBayes(fit = fit)
+
+      coef_to_test <- setdiff(colnames(design), "(Intercept)")
+      t_res <- limma::topTable(bayes, coef = coef_to_test, number = Inf, sort.by = "none")
+      
+      # Format p-values as a list for all covariates.
+      p <- t_res[,"P.Value"]
+      t <- t_res[,"t"]
+      output_seahorse$cor <- p
+      names(output_seahorse$cor) <- rownames(t_res)
+      names(t) <- rownames(t_res)
+      
+      # Run GSEA
+      fgseaRes <- NA
+      tryCatch({
+        statSorted <- sort(t, decreasing = TRUE)
+        fgseaRes <- fgsea::fgsea(pathways, statSorted, minSize=15, maxSize=500)
+      }, error = function(cond){
+        print(cond)
+      })
+      
+      output_seahorse$GSEA = fgseaRes
     }, error = function(cond){
-      print(cond)
+      warning("Could not compute empirical Bayes statistics for this phenotypic variable. Returning empty list.")
     })
-    
-    output_seahorse$GSEA = fgseaRes
   }else{
     warning("Phenotype has only one level. Returning NA for all gene associations.")
   }
@@ -769,7 +779,7 @@ phenotype_chisq <- function(phenotype, phenotypesToCompare, phenotypeType){
     pval <- NA
     V <- NA
     type <- "Chi-square"
-    if(nonzeroRowMarginalCount > 2 && nonzeroColMarginalCount > 2){
+    if(nonzeroRowMarginalCount >= 2 && nonzeroColMarginalCount >= 2){
       # Run the test. If a warning is thrown, switch to FFH.
       chisq <- withCallingHandlers(
         chisq.test(chisqTable),
@@ -855,7 +865,7 @@ phenotype_anova <- function(phenotype, phenotypesToCompare, phenotypeType){
       tryCatch({
         results <- anova(lm(as.numeric(as.character(x))~phenotype_vector))$`Pr(>F)`[1]
       }, error = function(cond){
-        warning("In this phenotype pair, all continuous values are missing for one phenotype level - NA result will be returned")
+        warning("In this phenotype pair, all continuous values are missing for all but one phenotype level - NA result will be returned")
       })
       return(results)
     }))
@@ -866,7 +876,8 @@ phenotype_anova <- function(phenotype, phenotypesToCompare, phenotypeType){
       tryCatch({
         results <- anova(lm(as.numeric(as.character(phenotype))~phenotype_vector))$`Pr(>F)`[1]
       }, error = function(cond){
-        warning("In this phenotype pair, all continuous values are missing for one phenotype level - NA result will be returned")
+        stop(cond)
+        warning("In this phenotype pair, all continuous values are missing for all but one phenotype level - NA result will be returned")
       })
       return(results)
     }))

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -563,6 +563,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "FFH"), "cor"], method = pval_adj_method)
         output_seahorse_padj_cat[which(output_seahorse_cat$testType == "Chi-square")] <- 
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "Chi-square"), "cor"], method = pval_adj_method)
+        str(output_seahorse_cat)
       }
       
       # Do continuous phenotypes.
@@ -605,6 +606,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "FFH"), "cor"], method = pval_adj_method)
         output_seahorse_padj_cat[which(output_seahorse_cat$testType == "Chi-square")] <- 
           stats::p.adjust(output_seahorse_cat[which(output_seahorse_cat$testType == "Chi-square"), "cor"], method = pval_adj_method)
+        str(output_seahorse_cat)
       }
       
       # Do continuous phenotypes.
@@ -643,6 +645,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
                                                     phenotypesToCompare = phenoDich, 
                                                     phenotypeType = phenoType)
         output_seahorse_padj_dich <- stats::p.adjust(output_seahorse_dich$cor, method = pval_adj_method)
+        str(output_seahorse_dich)
       }
       
       # Do nominal phenotypes.
@@ -657,6 +660,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
                                               phenotypesToCompare = phenoNom, 
                                               phenotypeType = phenoType)
         output_seahorse_padj_nom <- stats::p.adjust(output_seahorse_nom$cor, method = pval_adj_method)
+        str(output_seahorse_nom)
       }
 
       # Do continuous phenotypes.
@@ -671,6 +675,7 @@ computePhenotypeCorrelations <- function(phenotype, phenotype_dictionary, method
                                               phenotypesToCompare = phenoCon, 
                                             method = method)
         output_seahorse_padj_con <- rep(NA, nrow(output_seahorse_con))
+        str(output_seahorse_con)
       }
       
       # Concatenate categorical and continuous results.
@@ -747,23 +752,32 @@ phenotype_chisq <- function(phenotype, phenotypesToCompare, phenotypeType){
   # Run the comparisons one at a time because Chi-square and FFH cannot be scaled.
   chisqRes <- lapply(allPhenoPairTables, function(chisqTable) {
     
-    # Run the test. If a warning is thrown, switch to FFH.
+    # Check that we have 2 or more non-zero row marginals. Only run the test if we do.
+    rowMarginals <- rowSums(chisqTable)
+    nonzeroMarginalCount <- length(which(rowMarginals > 0))
+    pval <- NA
+    V <- NA
     type <- "Chi-square"
-    chisq <- withCallingHandlers(
-      chisq.test(chisqTable),
-      warning = function(w) {
-        if (grepl("Chi-squared approximation may be incorrect", w$message)) {
-          # Do not change only within the warning scope but also within the parent scope.
-          type <<- "FFH"
-          invokeRestart("muffleWarning")
+    if(nonzeroMarginalCount > 2){
+      # Run the test. If a warning is thrown, switch to FFH.
+      chisq <- withCallingHandlers(
+        chisq.test(chisqTable),
+        warning = function(w) {
+          if (grepl("Chi-squared approximation may be incorrect", w$message)) {
+            # Do not change only within the warning scope but also within the parent scope.
+            type <<- "FFH"
+            invokeRestart("muffleWarning")
+          }
         }
-      }
-    )
-    
-    # Get the p-value and Cramer's V.
-    pval <- chisq$p.value
-    V <- sqrt(chisq$statistic / (sum(chisqTable) * min(nrow(chisqTable) - 1, 
-                                                       ncol(chisqTable) - 1)))
+      )
+      
+      # Get the p-value and Cramer's V.
+      pval <- chisq$p.value
+      V <- sqrt(chisq$statistic / (sum(chisqTable) * min(nrow(chisqTable) - 1, 
+                                                         ncol(chisqTable) - 1)))
+    }else{
+      warning("Less than 2 nonzero marginals in the contingency table - Chi-square will return NA")
+    }
     return(list(pval = pval, v = V, testType = type))
   })
   chisqP <- unlist(lapply(chisqRes, function(res){
@@ -874,20 +888,25 @@ phenotype_ttest <- function(phenotype, phenotypesToCompare, phenotypeType){
     group2 <- phenotypesToCompare[which(phenotype_vector == levels[2]),]
     
     # Check that thresholds are met.
+    whichLevel1 <- length(which(phenotype_vector == levels[1]))
+    whichLevel2 <- length(which(phenotype_vector == levels[2]))
     meetsThreshold <- colSums(!is.na(group1)) >= 2 & colSums(!is.na(group2)) >= 2
     
     # Initialize result to NA.
     cor <- rep(NA, ncol(group1))
     names(cor) <- colnames(group1)
     
-    # Compute t-test where thresholds are met.
-    tresValid <- matrixTests::col_t_welch(
-      group1[, meetsThreshold, drop = FALSE],
-      group2[, meetsThreshold, drop = FALSE]
-    )
-    
-    # Compute remaining t-tests.
-    cor[meetsThreshold] <- tresValid$pvalue
+    # Only compute correlations if both levels are represented in the phenotype vector.
+    if(whichLevel1 > 0 && whichLevel2 > 0){
+      # Compute t-test where thresholds are met.
+      tresValid <- matrixTests::col_t_welch(
+        group1[, meetsThreshold, drop = FALSE],
+        group2[, meetsThreshold, drop = FALSE]
+      )
+      
+      # Compute remaining t-tests.
+      cor[meetsThreshold] <- tresValid$pvalue
+    }
     
   }else{
     cor <- unlist(lapply(1:ncol(phenotypesToCompare), function(i){

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -868,24 +868,46 @@ phenotype_ttest <- function(phenotype, phenotypesToCompare, phenotypeType){
   # Case 2 - the phenotype is numeric and the phenotypes to compare are dichotomous.
   # We cannot vectorize this and use t.test instead, which defaults to Welch's t-test.
   if(phenotypeType == "dichotomous"){
+    
+    # Split groups.
     phenotype_vector = factor(as.character(phenotype))
     levels <- unique(phenotype_vector)
     group1 <- phenotypesToCompare[which(phenotype_vector == levels[1]),]
     group2 <- phenotypesToCompare[which(phenotype_vector == levels[2]),]
-    tres <- matrixTests::col_t_welch(group1, group2)
-    cor = tres$pvalue
-    names(cor) <- rownames(tres)
+    
+    # Check that thresholds are met.
+    meetsThreshold <- colSums(!is.na(group1)) >= 2 & colSums(!is.na(group2)) >= 2
+    
+    # Initialize result to NA.
+    cor <- rep(NA, ncol(group1))
+    names(cor) <- colnames(group1)
+    
+    # Compute t-test where thresholds are met.
+    tresValid <- matrixTests::col_t_welch(
+      group1[, meetsThreshold, drop = FALSE],
+      group2[, meetsThreshold, drop = FALSE]
+    )
+    
+    # Compute remaining t-tests.
+    cor[meetsThreshold] <- tresValid$pvalue
+    
   }else{
     cor <- unlist(lapply(1:ncol(phenotypesToCompare), function(i){
       phenotype_vector = factor(as.character(phenotypesToCompare[,i]))
       levels <- unique(phenotype_vector)
       group1 <- phenotype[which(phenotype_vector == levels[1])]
       group2 <- phenotype[which(phenotype_vector == levels[2])]
-      tres <- t.test(group1, group2)
-      stat = tres$p.value
-      names(stat) <- rownames(tres)
+      stat <- NA
+      if(length(which(!is.na(group1))) > 2 && length(which(!is.na(group2))) > 2){
+        tres <- t.test(group1, group2)
+        stat = tres$p.value
+      }
+      names(stat) <- colnames(phenotypesToCompare)[i]
       return(stat)
     }))
+  }
+  if(length(which(is.na(cor))) > 0){
+    warning("Some phenotypes did not have sufficient sample sizes to perform a t-test - NAs will be returned")
   }
   
   # Return the data frame.

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -876,7 +876,6 @@ phenotype_anova <- function(phenotype, phenotypesToCompare, phenotypeType){
       tryCatch({
         results <- anova(lm(as.numeric(as.character(phenotype))~phenotype_vector))$`Pr(>F)`[1]
       }, error = function(cond){
-        stop(cond)
         warning("In this phenotype pair, all continuous values are missing for all but one phenotype level - NA result will be returned")
       })
       return(results)

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -827,7 +827,6 @@ phenotype_anova <- function(phenotype, phenotypesToCompare, phenotypeType){
     phenotype_vector = factor(as.character(phenotype))
     cor <- unlist(apply(phenotypesToCompare, MARGIN=2, function(x){
       results <- NA
-      names(results) <- colnames(phenotype_vector)
       tryCatch({
         results <- anova(lm(as.numeric(as.character(x))~phenotype_vector))$`Pr(>F)`[1]
       }, error = function(cond){
@@ -838,7 +837,6 @@ phenotype_anova <- function(phenotype, phenotypesToCompare, phenotypeType){
   }else{
     cor <- unlist(lapply(1:ncol(phenotypesToCompare), function(i){
       results <- NA
-      names(results) <- colnames(phenotype_vector)
       phenotype_vector <- factor(as.character(phenotypesToCompare[,i]))
       tryCatch({
         results <- anova(lm(as.numeric(as.character(phenotype))~phenotype_vector))$`Pr(>F)`[1]

--- a/R/SEAHORSE.R
+++ b/R/SEAHORSE.R
@@ -354,8 +354,7 @@ computeCorrelations <- function(expression, phenotype, phenotype_dictionary, pat
   for (i in 1:ncol(phenotype)){
     pheno = phenotype[,i]
     pheno_name = colnames(phenotype)[i]
-    print(colnames(phenotype)[i])
-    
+
     if (phenotype_dictionary[i] == "continuous"){
       output_seahorse = gsea_continuous(expression, pheno, pathways, method = method)
       output_seahorse_padj <- rep("NA", length(output_seahorse$cor))

--- a/man/seahorse.Rd
+++ b/man/seahorse.Rd
@@ -20,7 +20,8 @@ seahorse(
   compute_phenotype_cor = TRUE,
   assoc_method = "spearman",
   pval_adj_method = "none",
-  usage_report_file = NULL
+  usage_report_file = NULL,
+  verbose = FALSE
 )
 }
 \arguments{
@@ -56,7 +57,9 @@ for each coefficient.}
 \item{pval_adj_method}{Wrapper for p.adjust. Defaults to "none" (no adjustment). Other options are
 "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", and "fdr".}
 
-\item{usage_report_file}{Location where the usage report should be stored. Must be RDS format.
+\item{usage_report_file}{Location where the usage report should be stored. Must be RDS format.}
+
+\item{verbose}{Whether or not to print statements notifying user of run status.
 Outputs:}
 }
 \value{

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -593,7 +593,7 @@ test_that("seahorse function works", {
   phenotype_data_2_zeros[which(phenotype_data_2$grade == "C"), "sex"] <- NA
   result <- seahorse(expression_data_2, phenotype_data_2_zeros, phenotype_dictionary_2, pathways,
                      compute_gene_cor = FALSE, compute_phenotype_cor = TRUE)
-  expect_true(is.na(result$phenocor$stat["sex", "grade"])
+  expect_true(is.na(result$phenocor$stat["sex", "grade"]))
   
   # Check that a phenotype pair result will be set to NA if we have all continuous data missing
   # for all but one level (nominal).

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -580,9 +580,9 @@ test_that("seahorse function works", {
                                        "Dark Energy", "Binary Star System", "Black Dwarf"))
   result <- seahorse(expression_data, phenotype_data, phenotype_dictionary, uselessPathways,
                      compute_gene_cor = FALSE, compute_phenotype_cor = FALSE)
-  expect_equal(nrow(result$GSEA$sex, 0))
-  expect_equal(nrow(result$GSEA$height, 0))
-  expect_equal(nrow(result$GSEA$group, 0))
+  expect_equal(nrow(result$GSEA$sex), 0)
+  expect_equal(nrow(result$GSEA$height), 0)
+  expect_equal(nrow(result$GSEA$group), 0)
   
   # Check that a phenotype pair result will be set to NA if we have 2 or more zero marginals.
   phenotype_data_2_zeros <- phenotype_data_2

--- a/tests/testthat/test-seahorse.R
+++ b/tests/testthat/test-seahorse.R
@@ -535,4 +535,80 @@ test_that("seahorse function works", {
   expect_true(is.na(usage$GeneToGeneCor))
   expect_true(length(colnames(usage$PhenToGeneCor)) == 4)
   unlink("usage_file.RDS")
+  
+  # Test that statements print when verbose = TRUE.
+  expect_output(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                      compute_gene_cor = TRUE, compute_phenotype_cor = TRUE, assoc_method = "linear",
+                      verbose = TRUE),
+                "Running gene co-expression")
+  expect_output(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                         compute_gene_cor = TRUE, compute_phenotype_cor = TRUE, assoc_method = "linear",
+                         verbose = TRUE),
+                "Gene co-expression complete")
+  expect_output(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                         compute_gene_cor = TRUE, compute_phenotype_cor = TRUE, assoc_method = "linear",
+                         verbose = TRUE),
+                "Running phenotype associations")
+  expect_output(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                         compute_gene_cor = TRUE, compute_phenotype_cor = TRUE, assoc_method = "linear",
+                         verbose = TRUE),
+                "Phenotype associations complete")
+  expect_output(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                         compute_gene_cor = TRUE, compute_phenotype_cor = TRUE, assoc_method = "linear",
+                         verbose = TRUE),
+                "Running gene-phenotype associations")
+  expect_output(seahorse(expression_data, phenotype_data, phenotype_dictionary, pathways,
+                         compute_gene_cor = TRUE, compute_phenotype_cor = TRUE, assoc_method = "linear",
+                         verbose = TRUE),
+                "Gene-phenotype associations complete")
+  
+  # Check that NA values are returned when the phenotype has less than 2 levels.
+  phenotype_data_1_lev <- phenotype_data
+  phenotype_data_1_lev$sex <- rep("male", nrow(phenotype_data_1_lev))
+  result <- seahorse(expression_data, phenotype_data_1_lev, phenotype_dictionary, pathways,
+           compute_gene_cor = FALSE, compute_phenotype_cor = FALSE)
+  expect_equal(result$phenotype_association$sex$stat, NA)
+  expect_equal(result$GSEA$sex, NA)
+  
+  # Check that GSEA returns an empty list if it cannot run, e.g. if there is no pathway overlap.
+  uselessPathways <- list(pathway1 = paste(rep(c("Mercury", "Venus", "Earth", "Mars", "Jupiter", "Saturn", "Neptune"), 2),
+                                           c(rep(1, 8), rep(2, 8))),
+                          pathway2 = paste(rep(c("Nina", "Pinta", "Santa Maria"), 6),
+                                           c(rep(1, 3), rep(2, 3), rep(3, 3), rep(4, 3), rep(5, 3), rep(6, 3))),
+                          pathway3 = c("Neutron Star", "Supernova", "Black Hole", "Red Dwarf", "White Dwarf", "Red Giant",
+                                       "Blue Giant", "Nebula", "Oort Cloud", "Brown Dwarf", "Comet", "Asteroid", "Dark Matter",
+                                       "Dark Energy", "Binary Star System", "Black Dwarf"))
+  result <- seahorse(expression_data, phenotype_data, phenotype_dictionary, uselessPathways,
+                     compute_gene_cor = FALSE, compute_phenotype_cor = FALSE)
+  expect_equal(nrow(result$GSEA$sex, 0))
+  expect_equal(nrow(result$GSEA$height, 0))
+  expect_equal(nrow(result$GSEA$group, 0))
+  
+  # Check that a phenotype pair result will be set to NA if we have 2 or more zero marginals.
+  phenotype_data_2_zeros <- phenotype_data_2
+  phenotype_data_2_zeros[which(phenotype_data_2$grade == "A")[1:10], "sex"] <- "female"
+  phenotype_data_2_zeros[which(phenotype_data_2$grade == "A")[2:20], "sex"] <- "male"
+  phenotype_data_2_zeros[which(phenotype_data_2$grade == "A")[21:45], "sex"] <- NA
+  phenotype_data_2_zeros[which(phenotype_data_2$grade == "B"), "sex"] <- NA
+  phenotype_data_2_zeros[which(phenotype_data_2$grade == "C"), "sex"] <- NA
+  result <- seahorse(expression_data_2, phenotype_data_2_zeros, phenotype_dictionary_2, pathways,
+                     compute_gene_cor = FALSE, compute_phenotype_cor = TRUE)
+  expect_true(is.na(result$phenocor$stat["sex", "grade"])
+  
+  # Check that a phenotype pair result will be set to NA if we have all continuous data missing
+  # for all but one level (nominal).
+  phenotype_data_2_na <- phenotype_data_2
+  phenotype_data_2_na[which(phenotype_data_2$grade == "A"), "WBC"] <- NA
+  phenotype_data_2_na[which(phenotype_data_2$grade == "B"), "WBC"] <- NA
+  result <- seahorse(expression_data_2, phenotype_data_2_na, phenotype_dictionary_2, pathways,
+                     compute_gene_cor = FALSE, compute_phenotype_cor = TRUE)
+  expect_true(is.na(result$phenocor$stat["grade", "WBC"]))
+  
+  # Check that a phenotype pair result will be set to NA if we have all continuous data missing
+  # for one level (dichotomous).
+  phenotype_data_2_na <- phenotype_data_2
+  phenotype_data_2_na[which(phenotype_data_2$sex == "female"), "WBC"] <- NA
+  result <- seahorse(expression_data_2, phenotype_data_2_na, phenotype_dictionary_2, pathways,
+                     compute_gene_cor = FALSE, compute_phenotype_cor = TRUE)
+  expect_true(is.na(result$phenocor$stat["sex", "WBC"]))
 })


### PR DESCRIPTION
Added the following edge cases:

- Removed NA values in phenotype before computing levels
- Checked number of observations when running ANOVA and t-test
- Checked expected counts in Chi-square test (removed observed value check)
- Checked for column marginals when running Chi-square / Fisher test
- Removed NA values for limma models
- Added special case when only one variable is included in matrix t-test